### PR TITLE
feat(local-loader): add exclude_patterns to filter scan noise (node_modules, venv)

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -16,6 +16,14 @@
       "comment": "Your custom local skills (optional - directory doesn't need to exist)"
     }
   ],
+  "exclude_patterns": [
+    "**/node_modules/**",
+    "**/venv/**",
+    "**/.venv/**",
+    "**/site-packages/**",
+    "**/.git/**"
+  ],
+  "comment_exclude_patterns": "Glob patterns excluded when scanning local skill sources. Defaults filter out SKILL.md files bundled inside npm/pip packages. Set to [] to disable filtering.",
   "embedding_model": "all-MiniLM-L6-v2",
   "default_top_k": 3,
   "max_skill_content_chars": null,

--- a/packages/backend/src/claude_skills_mcp_backend/skill_loader.py
+++ b/packages/backend/src/claude_skills_mcp_backend/skill_loader.py
@@ -1,6 +1,7 @@
 """Skill loading and parsing functionality."""
 
 import base64
+import fnmatch
 import hashlib
 import json
 import logging
@@ -15,6 +16,27 @@ from urllib.parse import urlparse
 import httpx
 
 logger = logging.getLogger(__name__)
+
+
+# Default glob patterns excluded when scanning local skill sources.
+# These cover SKILL.md files bundled inside package directories (npm/pip), which
+# almost always represent third-party noise rather than user-authored skills.
+# Users can override per-source via `exclude_patterns` in their config.
+DEFAULT_LOCAL_EXCLUDE_PATTERNS: list[str] = [
+    "**/node_modules/**",
+    "**/venv/**",
+    "**/.venv/**",
+    "**/site-packages/**",
+    "**/.git/**",
+]
+
+
+def _is_excluded_path(skill_file: Path, patterns: list[str]) -> bool:
+    """Return True if the SKILL.md path matches any glob exclude pattern."""
+    if not patterns:
+        return False
+    path_str = str(skill_file)
+    return any(fnmatch.fnmatch(path_str, pattern) for pattern in patterns)
 
 
 class Skill:
@@ -362,6 +384,7 @@ def load_from_local(path: str, config: dict[str, Any] | None = None) -> list[Ski
         "allowed_image_extensions", [".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"]
     )
     max_image_size = config.get("max_image_size_bytes", 5242880)
+    exclude_patterns = config.get("exclude_patterns", DEFAULT_LOCAL_EXCLUDE_PATTERNS)
 
     try:
         local_path = Path(path).expanduser().resolve()
@@ -374,8 +397,19 @@ def load_from_local(path: str, config: dict[str, Any] | None = None) -> list[Ski
             logger.warning(f"Local path {path} is not a directory, skipping")
             return skills
 
-        # Find all SKILL.md files recursively
-        skill_files = list(local_path.rglob("SKILL.md"))
+        # Find all SKILL.md files recursively, excluding noise directories
+        # (node_modules / venv / etc) by default. See DEFAULT_LOCAL_EXCLUDE_PATTERNS.
+        all_skill_files = list(local_path.rglob("SKILL.md"))
+        skill_files = [
+            p for p in all_skill_files
+            if not _is_excluded_path(p, exclude_patterns)
+        ]
+        excluded_count = len(all_skill_files) - len(skill_files)
+        if excluded_count > 0:
+            logger.info(
+                f"Excluded {excluded_count} SKILL.md file(s) from {path} "
+                f"matching exclude_patterns"
+            )
 
         for skill_file in skill_files:
             try:

--- a/packages/backend/tests/test_skill_loader.py
+++ b/packages/backend/tests/test_skill_loader.py
@@ -129,3 +129,86 @@ def test_load_from_local_with_home_expansion(path_variation):
     # but it shouldn't crash
     skills = load_from_local(path_variation)
     assert isinstance(skills, list)
+
+
+def test_load_from_local_excludes_node_modules(tmp_path):
+    """SKILL.md files under node_modules/ must be excluded by default."""
+    # Real skill at the root
+    (tmp_path / "real-skill").mkdir()
+    (tmp_path / "real-skill" / "SKILL.md").write_text(
+        "---\nname: Real Skill\ndescription: A real user skill\n---\n# Real\n"
+    )
+
+    # Noise: SKILL.md bundled inside node_modules (e.g. dotenv's example skill)
+    nested = tmp_path / "some-project" / "node_modules" / "dotenv" / "skills" / "dotenv"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "---\nname: dotenv\ndescription: third-party noise\n---\n# noise\n"
+    )
+
+    skills = load_from_local(str(tmp_path))
+    names = {s.name for s in skills}
+
+    assert "Real Skill" in names
+    assert "dotenv" not in names, "node_modules SKILL.md must be excluded"
+
+
+def test_load_from_local_excludes_venv(tmp_path):
+    """SKILL.md files under venv/site-packages must be excluded by default."""
+    (tmp_path / "real-skill").mkdir()
+    (tmp_path / "real-skill" / "SKILL.md").write_text(
+        "---\nname: Real Skill\ndescription: A real skill\n---\n# Real\n"
+    )
+
+    # Noise: SKILL.md inside venv/site-packages (e.g. typer's bundled skill)
+    nested = (
+        tmp_path / "some-project" / "venv" / "lib" / "python3.12"
+        / "site-packages" / "typer" / ".agents" / "skills" / "typer"
+    )
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "---\nname: typer\ndescription: bundled noise\n---\n# noise\n"
+    )
+
+    skills = load_from_local(str(tmp_path))
+    names = {s.name for s in skills}
+
+    assert "Real Skill" in names
+    assert "typer" not in names, "venv/site-packages SKILL.md must be excluded"
+
+
+def test_load_from_local_custom_exclude_patterns(tmp_path):
+    """Custom exclude_patterns override the defaults."""
+    (tmp_path / "good").mkdir()
+    (tmp_path / "good" / "SKILL.md").write_text(
+        "---\nname: Good\ndescription: keep me\n---\n# Good\n"
+    )
+    (tmp_path / "bad").mkdir()
+    (tmp_path / "bad" / "SKILL.md").write_text(
+        "---\nname: Bad\ndescription: drop me\n---\n# Bad\n"
+    )
+
+    skills = load_from_local(str(tmp_path), config={"exclude_patterns": ["**/bad/**"]})
+    names = {s.name for s in skills}
+
+    assert names == {"Good"}
+
+
+def test_load_from_local_empty_exclude_patterns_disables_filter(tmp_path):
+    """An empty exclude_patterns list disables filtering (opt-out)."""
+    (tmp_path / "real-skill").mkdir()
+    (tmp_path / "real-skill" / "SKILL.md").write_text(
+        "---\nname: Real Skill\ndescription: A real skill\n---\n# Real\n"
+    )
+    nested = tmp_path / "some-project" / "node_modules" / "dotenv" / "skills" / "dotenv"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "---\nname: dotenv\ndescription: would normally be excluded\n---\n# noise\n"
+    )
+
+    skills = load_from_local(str(tmp_path), config={"exclude_patterns": []})
+    names = {s.name for s in skills}
+
+    # With no exclude_patterns, both must be loaded (legacy behavior)
+    assert "Real Skill" in names
+    assert "dotenv" in names


### PR DESCRIPTION
## Problem

When a user's local skill source (e.g., `~/.claude/skills`) is a symlink to or contains a workspace with multiple JS/Python projects, the recursive `local_path.rglob("SKILL.md")` in `load_from_local()` picks up SKILL.md files bundled inside `node_modules/dotenv/skills/`, `venv/.../typer/.agents/skills/`, etc. These are shipped by package authors and almost always represent third-party noise rather than user-authored skills, polluting `list_skills` results and degrading semantic search.

### Reproducer

```bash
ln -s ~/projects/my-skills ~/.claude/skills
cd ~/projects/my-skills/some-project && npm install dotenv
# Restart the backend — list_skills now includes three dotenv skills
```

In a real environment with three npm projects and one Python venv, I observed **8 noise SKILL.md files** sneaking in alongside 14 legitimate skills.

## Solution

Add an `exclude_patterns` config key (top-level, applied to all `local` sources). Patterns are matched against the full path via `fnmatch.fnmatch`.

**Default value** (filters common noise):

```json
[
  "**/node_modules/**",
  "**/venv/**",
  "**/.venv/**",
  "**/site-packages/**",
  "**/.git/**"
]
```

**Opt-out**: set `"exclude_patterns": []` to disable filtering and restore legacy behaviour.

## Changes

- `packages/backend/src/claude_skills_mcp_backend/skill_loader.py`
  - New `DEFAULT_LOCAL_EXCLUDE_PATTERNS` constant.
  - New helper `_is_excluded_path(skill_file, patterns)`.
  - `load_from_local()` reads `exclude_patterns` from config and filters `rglob` results.
  - Logs the count of excluded files when > 0.
- `config.example.json`
  - Documents the new key with an inline comment.
- `packages/backend/tests/test_skill_loader.py`
  - 4 new tests covering node_modules exclusion, venv/site-packages exclusion, custom patterns, and the empty-list opt-out.

## Backward compatibility

The default patterns target obvious third-party directories. User-authored skills under `~/.claude/skills/<skill-name>/SKILL.md` are unaffected. Users who want the previous behaviour can set `"exclude_patterns": []`. No API or schema breaking changes.

## Tests

All 15 tests pass (11 existing + 4 new) on Python 3.12:

```
============================== 15 passed in 0.09s ==============================
```

## Note

I see the README announces the project is no longer maintained — opening this anyway so the fix is publicly available for anyone running their own fork. Happy to close if not useful.